### PR TITLE
Create HTML documentation for the project

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE>
+<html lang="en">
+  <head>
+    <meta charset="utf8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TKT - Documentation</title>
+  </head>
+  <body>
+    <header>
+      <h1>TKT Documentation</h1>
+    </header>
+    <main>
+      <p>This is where TKT development will be documented.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
This is just a placeholder for the web page that will be created. GitHub only allows for the `docs/` name.
Either that, the project root (not a good idea) or a branch specifically made for that (usually called `gh-pages`), which is also confusing in my opinion.

After configured properly, the page should show up at https://ETJAKEOC.github.io/TKT/ with all the files from the `docs` directory (just the `index.html` for now).